### PR TITLE
[script][pick] add autoloot support

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -85,7 +85,10 @@ class Pick
     @disarm_careful_threshold = @settings.pick['disarm_careful_threshold'] || 5
     @disarm_too_hard_threshold = @settings.pick['disarm_too_hard_threshold'] || 10
     @too_hard_container = @settings.pick['too_hard_container']
+	@autoloot_container = @settings.autoloot_container
 
+	@gem_nouns = get_data('items').gem_nouns
+    	
     @assumed_difficulty = args.assume || @settings.pick['assumed_difficulty']
 
     @trap_blacklist = @settings.pick['trap_blacklist'] || []
@@ -132,6 +135,8 @@ class Pick
       echo "- pick_normal: #{@pick_normal_threshold}"
       echo "- pick_careful: #{@pick_careful_threshold}"
       echo "- assumed_difficulty: #{@assumed_difficulty}"
+	  echo "- autoloot_container: #{@autoloot_container}"
+	  echo "  @gem_nouns: #{@gem_nouns}"
     end
 
     if args.refill
@@ -226,6 +231,7 @@ class Pick
     Flags.add('more-locks', 'You discover another lock protecting')
     Flags.add('glance-no-traps', 'It looks like there are no traps left on')
     Flags.add('glance-no-locks', 'It looks like there are no locks left on')
+    Flags.add('full-lootpouch', 'A (.*) is full\!  There\'s no room for loot\!')
   end
 
   def crack_boxes
@@ -708,34 +714,95 @@ class Pick
 
   def loot(box_noun)
     echo "Looting #{box_noun}..." if @debug
-    if DRC.bput("open my #{box_noun}", /You open/, /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
+    
+    if DRC.bput("open my #{box_noun}", /^In the .* you see .*\./, 'That is already open', 'It is locked') == 'It is locked'
       echo 'Bug: Tried to loot locked box...'
       return
     end
-
-    if (@settings.fill_pouch_with_box || @settings.loot_specials.empty?)
+		
+    #pouch full, fill from lootpouch then try again      	
+    if Flags['full-lootpouch']
+      Flags.reset('full-lootpouch')
+      echo 'last match:, #{Regexp.last_match}'	 
+      echo 'last match0:, #{Regexp.last_match(0)}'	 
+      echo 'last match1:, #{Regexp.last_match(1)}'	       
+      case DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{@settings.autoloot_container}", /You open/, /is too full to fit another gem/, /is too full to fit any more gems/, /You'd better tie it up before putting/, /You'll need to tie it up before/)        
+      when /is too full to fit another gem/, /is too full to fit any more gems/
+        swap_out_full_gempouch
+        #fill pouch from container
+        DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{@settings.autoloot_container}", /You open/, /You fill your/)
+        DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{box_noun}", 'You fill your', 'You open your', 'What were you referring to', /any gems/, /too full to fit/)      
+        when /You'd better tie it up/, /You'll need to tie it up before/
+          #tie pouch once there is some gems in it
+          DRC.bput("tie my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun}", 'You tie', "it's empty?", 'has already been tied off') if @tie_gem_pouches
+          DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{@settings.autoloot_container}", /You open/, /is too full to fit another gem/, /is too full to fit any more gems/, /You'd better tie it up before putting/, /You'll need to tie it up before/)    		
+        end
+    end	  
+				
+    
+    if (@settings.fill_pouch_with_box || @settings.loot_specials.empty?) && !(@settings.fill_pouch_with_box == false) 
       # Don't handle full pouches here, cause if we do, we can't tie them (when they're empty)
-      DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{box_noun}",
-        'You fill your', 'You open your', 'What were you referring to', /any gems/, /too full to fit/)
+      DRC.bput("fill my #{@settings.gem_pouch_adjective} #{@settings.gem_pouch_noun} with my #{box_noun}", 'You fill your', 'You open your', 'What were you referring to', /any gems/, /too full to fit/)
     end
 
-    box_items = DRCI.get_item_list(box_noun, 'look');
-    loot = box_items.map { |item| DRC.get_noun(item) }
+    box_items = DRCI.get_item_list(box_noun, 'look');	
+    echo("boxitems = #{box_items}") if @debug
+    if box_items == 'There is nothing in there\.'
+      echo 'All loot gathered, dumping box'
+      return
+    end
+	
+    #loot each item if there is anything left.
+    loot = box_items.map { |item| item }
     echo "box items: #{box_items} - loot: #{loot}" if @debug
-
     loot.each { |item| loot_item(item, box_noun) }
 
     # Recurse for very full boxes
     loot(box_noun) if loot.last() =~ /stuff/i
+
   end
 
   def loot_item(item, box)
+    	
+    item_long = item
+    item = DRC.get_noun(item)
+	
+    echo("loot_item = #{item}") if @debug
+    echo("item_long = #{item_long}") if @debug
+	
     # We don't touch glowing fragments, since we took off all our armor...
     return if item =~ /fragment/i
     # Stuff happens for very full boxes, and isn't really loot
     return if item =~ /stuff/i
 
-    item_long = nil
+    #search for loose gems
+    if @gem_nouns.find { |thing| thing =~ /\b#{item}\b/i }
+      echo "gem found, getting and stowing it"
+        DRC.bput("get #{item} from my #{box}", 'You get (.*) from inside', 'You pick up \d* \w* (?:lirum|dokora|kronar)s?')
+        case DRC.bput("stow my #{item}", /You put/, /You open/, /is too full to fit another gem/, /You'd better tie it up before putting/)
+      when /You put/, /You open/
+        return
+      when /You'd better tie it up/, /is too full to fit another gem/
+        swap_out_full_gempouch
+      end
+      return
+    end
+	
+	  #search for special items
+    special = @settings.loot_specials.find { |x| /\b#{x['name']}\b/i =~ item_long }
+    if special
+      echo "special item identified #{item}"
+      DRCI.put_away_item?(item, special['bag'])
+      return
+    end
+	
+    #if its trash leave it in the box and exit
+    if @trash_nouns.find { |thing| item =~ /\b#{item}\b/i }
+	    echo "trash item identified, left it in the box for trashing: #{item}"
+	    return
+	  end
+	
+    #get any loose other items	
     case DRC.bput("get #{item} from my #{box}", 'You get (.*) from inside', 'You pick up \d* \w* (?:lirum|dokora|kronar)s?')
     when /You pick up/ # Coins
       return
@@ -744,12 +811,7 @@ class Pick
       echo "Looted: #{item_long}" if @debug
     end
 
-    special = @settings.loot_specials.find { |x| /\b#{x['name']}\b/i =~ item_long }
-    if special
-      DRCI.put_away_item?(item, special['bag'])
-      return
-    end
-
+	  #stow the items if its in loot_nouns
     if @loot_nouns.find { |thing| item_long.include?(thing) && !item_long.include?('sunstone runestone') }
       case DRC.bput("stow my #{item}", /You put/, /You open/, /is too full to fit another gem/, /You'd better tie it up before putting/)
       when /You put/, /You open/
@@ -760,6 +822,7 @@ class Pick
       return
     end
 
+	  #possible unrecognized item log it & trash manually just in case.
     if @trash_nouns.find { |thing| item_long =~ /\b#{thing}\b/i }
       DRCI.dispose_trash(item, @worn_trashcan, @worn_trashcan_verb)
     else
@@ -840,6 +903,7 @@ before_dying do
   Flags.delete('more-locks')
   Flags.delete('glance-no-traps')
   Flags.delete('glance-no-locks')
+  Flags.delete('full-lootpouch')
 end
 
 Pick.new


### PR DESCRIPTION
- added autolooting of box contents to save time picking out gems one at a time and coins. Alot faster boxing!
- left unwanted items in boxes so they can be disposed of quicker rather than pulling them out one by one
- users must add a autoloot_container: lootpouch etc to their YAML
- user must set autoloot autobox to true,  autoloot gems and autoloot coins with autoloot for it to work.

If its possible to pickup a lootcontainer label automatically from the match that would be ideal then nothing has to be added to YAMLS but wasnt sure how best to do that  (maybe from the new flag regex?)

discord MattG.